### PR TITLE
gauge_controller: avoid empty type name

### DIFF
--- a/contracts/gauge_controller.sol
+++ b/contracts/gauge_controller.sol
@@ -129,6 +129,9 @@ contract GaugeController is AccessControlUpgradeable, ReentrancyGuardUpgradeable
     {
         require(nGaugeTypes < MAX_NUM, "Can't add more gauge types");
 
+        bytes memory typeNameBytes = bytes(_typeName);
+        require(typeNameBytes.length > 0, "Empty type name");
+
         uint128 gType = nGaugeTypes;
         typeNames[gType] = _typeName;
         nGaugeTypes = gType + 1;


### PR DESCRIPTION
If we allow the addition of gauge types without valid type names, then we cannot determine whether a type has been correctly added when we query type names.

The following content shows the querying results reflecting the issue mentioned above:

```
type: 0, name: 
type: 1, name: 
type: 2, name: TYPE2
type: 3, name: TYPE3
type: 4, name: TYPE4
type: 5, name: 
type: 6, name: 
```